### PR TITLE
Make DnsMessageBase.Encode() method externally visible

### DIFF
--- a/ARSoft.Tools.Net/Dns/DnsMessageBase.cs
+++ b/ARSoft.Tools.Net/Dns/DnsMessageBase.cs
@@ -591,21 +591,21 @@ namespace ARSoft.Tools.Net.Dns
 		#region Serializing
 		protected virtual void PrepareEncoding() {}
 
-		internal int Encode(bool addLengthPrefix, out byte[] messageData)
+		public int Encode(bool addLengthPrefix, out byte[] messageData)
 		{
 			byte[] newTSigMac;
 
 			return Encode(addLengthPrefix, null, false, out messageData, out newTSigMac);
 		}
 
-		internal int Encode(bool addLengthPrefix, byte[] originalTsigMac, out byte[] messageData)
+	    public int Encode(bool addLengthPrefix, byte[] originalTsigMac, out byte[] messageData)
 		{
 			byte[] newTSigMac;
 
 			return Encode(addLengthPrefix, originalTsigMac, false, out messageData, out newTSigMac);
 		}
 
-		internal int Encode(bool addLengthPrefix, byte[] originalTsigMac, bool isSubSequentResponse, out byte[] messageData, out byte[] newTSigMac)
+	    public int Encode(bool addLengthPrefix, byte[] originalTsigMac, bool isSubSequentResponse, out byte[] messageData, out byte[] newTSigMac)
 		{
 			PrepareEncoding();
 


### PR DESCRIPTION
Its useful to be able to get the byte-level representation of a DnsMessage.