### PR TITLE
Removed unnecessary period from the DomainName.ToString() method

### DIFF
--- a/ARSoft.Tools.Net/DomainName.cs
+++ b/ARSoft.Tools.Net/DomainName.cs
@@ -314,7 +314,7 @@ namespace ARSoft.Tools.Net
 			if (_toString != null)
 				return _toString;
 
-			return (_toString = String.Join(".", _labels.Select(x => x.ToMasterfileLabelRepresentation(true))) + ".");
+			return (_toString = String.Join(".", _labels.Select(x => x.ToMasterfileLabelRepresentation(true))));
 		}
 
 		private int? _hashCode;


### PR DESCRIPTION
Currently, if given a domain name, such as "google.com", the ToString() method returns "google.com.". That is incorrect.