### PR TITLE
Minor fixes to pass along transport parameters correctly

### DIFF
--- a/ARSoft.Tools.Net/Dns/DnsServer.cs
+++ b/ARSoft.Tools.Net/Dns/DnsServer.cs
@@ -153,7 +153,7 @@ namespace ARSoft.Tools.Net.Dns
 					DnsMessageBase response;
 					try
 					{
-						response = await ProcessMessageAsync(query, ProtocolType.Tcp, connection.RemoteEndPoint!);
+						response = await ProcessMessageAsync(query, connection.Transport.TransportProtocol == TransportProtocol.Udp ? ProtocolType.Udp : ProtocolType.Tcp, connection.RemoteEndPoint!);
 					}
 					catch (Exception ex)
 					{

--- a/ARSoft.Tools.Net/Dns/Transport/UdpServerTransport.cs
+++ b/ARSoft.Tools.Net/Dns/Transport/UdpServerTransport.cs
@@ -61,7 +61,7 @@ public class UdpServerTransport : IServerTransport
 	/// <param name="bindAddress">The IP address on which the transport should listen</param>
 	/// <param name="timeout">The read an write timeout in milliseconds</param>
 	public UdpServerTransport(IPAddress bindAddress, int timeout = 5000)
-		: this(new IPEndPoint(IPAddress.IPv6Any, DEFAULT_PORT), timeout) { }
+		: this(new IPEndPoint(bindAddress, DEFAULT_PORT), timeout) { }
 
 	/// <summary>
 	///   Creates a new instance of the UdpServerTransport


### PR DESCRIPTION
This addresses a couple of minor issues I ran into:

* The caller's specified `bindAddress` for `UdpServerTransport` is ignored if using the `IPAddress`-based constructor; `IPAddress.IPv6Any` is always used instead
* The `protocolType` passed to `ProcessMessageAsync`, which is exposed via `QueryReceived` is *always* `ProtocolType.Tcp`, regardless how the client connected