### PR TITLE
Fix base32hex bug and simplify BaseEncoding implementation

### DIFF
--- a/ARSoft.Tools.Net.Tests/ARSoft.Tools.Net.Tests.csproj
+++ b/ARSoft.Tools.Net.Tests/ARSoft.Tools.Net.Tests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ARSoft.Tools.Net\ARSoft.Tools.Net.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ARSoft.Tools.Net.Tests/BaseEncodingTests.cs
+++ b/ARSoft.Tools.Net.Tests/BaseEncodingTests.cs
@@ -1,0 +1,211 @@
+﻿using System.Text;
+using Xunit;
+
+namespace ARSoft.Tools.Net.Tests
+{
+    public class RFC4648_Test_Vectors_Base16
+    {
+        // Test vectors taken from RFC4648
+        // https://www.rfc-editor.org/rfc/rfc4648#section-10
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("f", "66")]
+        [InlineData("fo", "666F")]
+        [InlineData("foo", "666F6F")]
+        [InlineData("foob", "666F6F62")]
+        [InlineData("fooba", "666F6F6261")]
+        [InlineData("foobar", "666F6F626172")]
+        public void Base16_TestVectors_Encode(string plain, string baseEncoded)
+        {
+            var inputBytes = Encoding.ASCII.GetBytes(plain);
+            var encoded = inputBytes.ToBase16String();
+
+            Assert.Equal(baseEncoded, encoded);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("f", "66")]
+        [InlineData("fo", "666F")]
+        [InlineData("foo", "666F6F")]
+        [InlineData("foob", "666F6F62")]
+        [InlineData("fooba", "666F6F6261")]
+        [InlineData("foobar", "666F6F626172")]
+        public void Base16_TestVectors_Decode(string plain, string baseEncoded)
+        {
+            var outputBytes = baseEncoded.FromBase16String();
+            var decoded = Encoding.ASCII.GetString(outputBytes);
+
+            Assert.Equal(plain, decoded);
+        }
+    }
+
+    public class RFC4648_Test_Vectors_Base32
+    {
+        // Test vectors taken from RFC4648
+        // https://www.rfc-editor.org/rfc/rfc4648#section-10
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("f", "MY======")]
+        [InlineData("fo", "MZXQ====")]
+        [InlineData("foo", "MZXW6===")]
+        [InlineData("foob", "MZXW6YQ=")]
+        [InlineData("fooba", "MZXW6YTB")]
+        [InlineData("foobar", "MZXW6YTBOI======")]
+        public void Base32_TestVectors_Encode(string plain, string baseEncoded)
+        {
+            var inputBytes = Encoding.ASCII.GetBytes(plain);
+            var encoded = inputBytes.ToBase32String();
+
+            Assert.Equal(baseEncoded, encoded);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("f", "MY======")]
+        [InlineData("fo", "MZXQ====")]
+        [InlineData("foo", "MZXW6===")]
+        [InlineData("foob", "MZXW6YQ=")]
+        [InlineData("fooba", "MZXW6YTB")]
+        [InlineData("foobar", "MZXW6YTBOI======")]
+        public void Base32_TestVectors_Decode(string plain, string baseEncoded)
+        {
+            var outputBytes = baseEncoded.FromBase32String();
+            var decoded = Encoding.ASCII.GetString(outputBytes);
+
+            Assert.Equal(plain, decoded);
+        }
+    }
+
+    public class RFC4648_Test_Vectors_Base32Hex
+    {
+        // Test vectors taken from RFC4648
+        // https://www.rfc-editor.org/rfc/rfc4648#section-10
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("f", "CO======")]
+        [InlineData("fo", "CPNG====")]
+        [InlineData("foo", "CPNMU===")]
+        [InlineData("foob", "CPNMUOG=")]
+        [InlineData("fooba", "CPNMUOJ1")]
+        [InlineData("foobar", "CPNMUOJ1E8======")]
+        public void Base32Hex_TestVectors_Encode(string plain, string baseEncoded)
+        {
+            var inputBytes = Encoding.ASCII.GetBytes(plain);
+            var encoded = inputBytes.ToBase32HexString();
+
+            Assert.Equal(baseEncoded, encoded);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("f", "CO======")]
+        [InlineData("fo", "CPNG====")]
+        [InlineData("foo", "CPNMU===")]
+        [InlineData("foob", "CPNMUOG=")]
+        [InlineData("fooba", "CPNMUOJ1")]
+        [InlineData("foobar", "CPNMUOJ1E8======")]
+        public void Base32Hex_TestVectors_Decode(string plain, string baseEncoded)
+        {
+            var outputBytes = baseEncoded.FromBase32HexString();
+            var decoded = Encoding.ASCII.GetString(outputBytes);
+
+            Assert.Equal(plain, decoded);
+        }
+    }
+
+
+    public class RFC4648_Test_Vectors_Base64
+    {
+        // Test vectors taken from RFC4648
+        // https://www.rfc-editor.org/rfc/rfc4648#section-10
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("f", "Zg==")]
+        [InlineData("fo", "Zm8=")]
+        [InlineData("foo", "Zm9v")]
+        [InlineData("foob", "Zm9vYg==")]
+        [InlineData("fooba", "Zm9vYmE=")]
+        [InlineData("foobar", "Zm9vYmFy")]
+        public void Base64_TestVectors_Encode(string plain, string baseEncoded)
+        {
+            var inputBytes = Encoding.ASCII.GetBytes(plain);
+            var encoded = inputBytes.ToBase64String();
+
+            Assert.Equal(baseEncoded, encoded);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("f", "Zg==")]
+        [InlineData("fo", "Zm8=")]
+        [InlineData("foo", "Zm9v")]
+        [InlineData("foob", "Zm9vYg==")]
+        [InlineData("fooba", "Zm9vYmE=")]
+        [InlineData("foobar", "Zm9vYmFy")]
+        public void Base64_TestVectors_Decode(string plain, string baseEncoded)
+        {
+            var outputBytes = baseEncoded.FromBase64String();
+            var decoded = Encoding.ASCII.GetString(outputBytes);
+
+            Assert.Equal(plain, decoded);
+        }
+    }
+
+    public class RFC4648_Test_Vectors_Base64Url
+    {
+        // Test vectors taken from RFC4648
+        // https://www.rfc-editor.org/rfc/rfc4648#section-10
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("f", "Zg==")]
+        [InlineData("fo", "Zm8=")]
+        [InlineData("foo", "Zm9v")]
+        [InlineData("foob", "Zm9vYg==")]
+        [InlineData("fooba", "Zm9vYmE=")]
+        [InlineData("foobar", "Zm9vYmFy")]
+        public void Base64Url_TestVectors_Encode(string plain, string baseEncoded)
+        {
+            var inputBytes = Encoding.ASCII.GetBytes(plain);
+            var encoded = inputBytes.ToBase64UrlString();
+
+            Assert.Equal(baseEncoded, encoded);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("f", "Zg==")]
+        [InlineData("fo", "Zm8=")]
+        [InlineData("foo", "Zm9v")]
+        [InlineData("foob", "Zm9vYg==")]
+        [InlineData("fooba", "Zm9vYmE=")]
+        [InlineData("foobar", "Zm9vYmFy")]
+        public void Base64Url_TestVectors_Decode(string plain, string baseEncoded)
+        {
+            var outputBytes = baseEncoded.FromBase64UrlString();
+            var decoded = Encoding.ASCII.GetString(outputBytes);
+
+            Assert.Equal(plain, decoded);
+        }
+    }
+
+
+    public class BaseEncodingRegressionTests
+    {
+        [Fact]
+        public void Base32Hex_Example_That_Used_to_Get_Corrupted()
+        {
+            var input = "NI9BSNE6JGFGO330HU4KGSP09POHFG62";
+
+            var asBytes = input.FromBase32HexString();
+            var encodedString = asBytes.ToBase32HexString();
+
+            Assert.Equal(input, encodedString);
+        }
+    }
+}

--- a/ARSoft.Tools.Net.sln
+++ b/ARSoft.Tools.Net.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ARSoft.Tools.Net", "ARSoft.
 EndProject
 Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation", "Documentation\Documentation.shfbproj", "{D84BE2AC-9E8C-45CA-9511-D986D0B06D9B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ARSoft.Tools.Net.Tests", "ARSoft.Tools.Net.Tests\ARSoft.Tools.Net.Tests.csproj", "{8E416DC5-41C1-42BD-8D64-E54F6D6A5F24}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +22,10 @@ Global
 		{D84BE2AC-9E8C-45CA-9511-D986D0B06D9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D84BE2AC-9E8C-45CA-9511-D986D0B06D9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D84BE2AC-9E8C-45CA-9511-D986D0B06D9B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E416DC5-41C1-42BD-8D64-E54F6D6A5F24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E416DC5-41C1-42BD-8D64-E54F6D6A5F24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E416DC5-41C1-42BD-8D64-E54F6D6A5F24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E416DC5-41C1-42BD-8D64-E54F6D6A5F24}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ARSoft.Tools.Net/BaseEncoding.cs
+++ b/ARSoft.Tools.Net/BaseEncoding.cs
@@ -16,580 +16,250 @@
 // limitations under the License.
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace ARSoft.Tools.Net
 {
-	/// <summary>
-	///   <para>Extension class for encoding and decoding Base16, Base32 and Base64</para>
-	///   <para>
-	///     Defined in
-	///     <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-	///   </para>
-	/// </summary>
-	public static class BaseEncoding
-	{
-		#region Helper
-		private static Dictionary<char, byte> GetAlphabet(string alphabet, bool isCaseIgnored)
-		{
-			Dictionary<char, byte> res = new Dictionary<char, byte>(isCaseIgnored ? 2 * alphabet.Length : alphabet.Length);
-
-			for (byte i = 0; i < alphabet.Length; i++)
-			{
-				res[alphabet[i]] = i;
-			}
-
-			if (isCaseIgnored)
-			{
-				alphabet = alphabet.ToLowerInvariant();
-				for (byte i = 0; i < alphabet.Length; i++)
-				{
-					res[alphabet[i]] = i;
-				}
-			}
-
-			return res;
-		}
-		#endregion
-
-		#region Base16
-		private const string _BASE16_ALPHABET = "0123456789ABCDEF";
-		private static readonly char[] _base16Alphabet = _BASE16_ALPHABET.ToCharArray();
-		private static readonly Dictionary<char, byte> _base16ReverseAlphabet = GetAlphabet(_BASE16_ALPHABET, true);
-
-		/// <summary>
-		///   Decodes a Base16 string as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inData"> An Base16 encoded string. </param>
-		/// <returns> Decoded data </returns>
-		public static byte[] FromBase16String(this string inData)
-		{
-			return inData.ToCharArray().FromBase16CharArray(0, inData.Length);
-		}
-
-		/// <summary>
-		///   Decodes a Base16 char array as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inData"> An Base16 encoded char array. </param>
-		/// <param name="offset"> An offset in inData. </param>
-		/// <param name="length"> The number of elements of inData to decode. </param>
-		/// <returns> Decoded data </returns>
-		public static byte[] FromBase16CharArray(this char[] inData, int offset, int length)
-		{
-			byte[] res = new byte[length / 2];
-
-			int inPos = offset;
-			int outPos = 0;
-
-			while (inPos < offset + length)
-			{
-				res[outPos++] = (byte) ((_base16ReverseAlphabet[inData[inPos++]] << 4) + _base16ReverseAlphabet[inData[inPos++]]);
-			}
-
-			return res;
-		}
-
-		/// <summary>
-		///   Converts a byte array to its corresponding Base16 encoding described in
-		///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inArray"> An array of 8-bit unsigned integers. </param>
-		/// <returns> Encoded string </returns>
-		public static string ToBase16String(this byte[] inArray)
-		{
-			return inArray.ToBase16String(0, inArray.Length);
-		}
-
-		/// <summary>
-		///   Converts a byte array to its corresponding Base16 encoding described in
-		///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inArray"> An array of 8-bit unsigned integers. </param>
-		/// <param name="offset"> An offset in inArray. </param>
-		/// <param name="length"> The number of elements of inArray to convert. </param>
-		/// <returns> Encoded string </returns>
-		public static string ToBase16String(this byte[] inArray, int offset, int length)
-		{
-			char[] outData = new char[length * 2];
-
-			int inPos = offset;
-			int inEnd = offset + length;
-			int outPos = 0;
-
-			while (inPos < inEnd)
-			{
-				outData[outPos++] = _base16Alphabet[(inArray[inPos] >> 4) & 0x0f];
-				outData[outPos++] = _base16Alphabet[inArray[inPos++] & 0x0f];
-			}
-
-			return new string(outData);
-		}
-		#endregion
-
-		#region Base32
-		private const string _BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567=";
-		private static readonly char[] _base32Alphabet = _BASE32_ALPHABET.ToCharArray();
-		private static readonly Dictionary<char, byte> _base32ReverseAlphabet = GetAlphabet(_BASE32_ALPHABET, true);
-
-		/// <summary>
-		///   Decodes a Base32 string as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inData"> An Base32 encoded string. </param>
-		/// <returns> Decoded data </returns>
-		public static byte[] FromBase32String(this string inData)
-		{
-			return inData.ToCharArray().FromBase32CharArray(0, inData.Length);
-		}
-
-		/// <summary>
-		///   Decodes a Base32 char array as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inData"> An Base32 encoded char array. </param>
-		/// <param name="offset"> An offset in inData. </param>
-		/// <param name="length"> The number of elements of inData to decode. </param>
-		/// <returns> Decoded data </returns>
-		public static byte[] FromBase32CharArray(this char[] inData, int offset, int length)
-		{
-			return inData.FromBase32CharArray(offset, length, _base32ReverseAlphabet);
-		}
-
-		/// <summary>
-		///   Converts a byte array to its corresponding Base32 encoding described in
-		///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inArray"> An array of 8-bit unsigned integers. </param>
-		/// <returns> Encoded string </returns>
-		public static string ToBase32String(this byte[] inArray)
-		{
-			return inArray.ToBase32String(0, inArray.Length);
-		}
-
-		/// <summary>
-		///   Converts a byte array to its corresponding Base32 encoding described in
-		///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inArray"> An array of 8-bit unsigned integers. </param>
-		/// <param name="offset"> An offset in inArray. </param>
-		/// <param name="length"> The number of elements of inArray to convert. </param>
-		/// <returns> Encoded string </returns>
-		public static string ToBase32String(this byte[] inArray, int offset, int length)
-		{
-			return inArray.ToBase32String(offset, length, _base32Alphabet);
-		}
-
-		private const string _BASE32_HEX_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUV=";
-		private static readonly char[] _base32HexAlphabet = _BASE32_HEX_ALPHABET.ToCharArray();
-		private static readonly Dictionary<char, byte> _base32HexReverseAlphabet = GetAlphabet(_BASE32_HEX_ALPHABET, true);
-
-		/// <summary>
-		///   Decodes a Base32Hex string as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inData"> An Base32Hex encoded string. </param>
-		/// <returns> Decoded data </returns>
-		public static byte[] FromBase32HexString(this string inData)
-		{
-			return inData.ToCharArray().FromBase32HexCharArray(0, inData.Length);
-		}
-
-		/// <summary>
-		///   Decodes a Base32Hex char array as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inData"> An Base32Hex encoded char array. </param>
-		/// <param name="offset"> An offset in inData. </param>
-		/// <param name="length"> The number of elements of inData to decode. </param>
-		/// <returns> Decoded data </returns>
-		public static byte[] FromBase32HexCharArray(this char[] inData, int offset, int length)
-		{
-			return inData.FromBase32CharArray(offset, length, _base32HexReverseAlphabet);
-		}
-
-		/// <summary>
-		///   Converts a byte array to its corresponding Base32Hex encoding described in
-		///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inArray"> An array of 8-bit unsigned integers. </param>
-		/// <returns> Encoded string </returns>
-		public static string ToBase32HexString(this byte[] inArray)
-		{
-			return inArray.ToBase32HexString(0, inArray.Length);
-		}
-
-		/// <summary>
-		///   Converts a byte array to its corresponding Base32Hex encoding described in
-		///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inArray"> An array of 8-bit unsigned integers. </param>
-		/// <param name="offset"> An offset in inArray. </param>
-		/// <param name="length"> The number of elements of inArray to convert. </param>
-		/// <returns> Encoded string </returns>
-		public static string ToBase32HexString(this byte[] inArray, int offset, int length)
-		{
-			return inArray.ToBase32String(offset, length, _base32HexAlphabet);
-		}
-
-		private static byte[] FromBase32CharArray(this char[] inData, int offset, int length, Dictionary<char, byte> alphabet)
-		{
-			int paddingCount = 0;
-			while (paddingCount < 6)
-			{
-				if (alphabet[inData[offset + length - paddingCount - 1]] != 32)
-					break;
-
-				paddingCount++;
-			}
-
-			int remain;
-			switch (paddingCount)
-			{
-				case 6:
-					remain = 1;
-					break;
-				case 4:
-					remain = 2;
-					break;
-				case 3:
-					remain = 3;
-					break;
-				case 1:
-					remain = 4;
-					break;
-				default:
-					remain = 0;
-					break;
-			}
-
-			int outSafeLength = (length - paddingCount) / 8 * 5;
-
-			byte[] res = new byte[outSafeLength + remain];
-
-			int inPos = offset;
-			int outPos = 0;
-
-			byte[] buffer = new byte[8];
-
-			while (outPos < outSafeLength)
-			{
-				for (int i = 0; i < 8; i++)
-				{
-					buffer[i] = alphabet[inData[inPos++]];
-				}
-
-				res[outPos++] = (byte) ((buffer[0] << 3) | ((buffer[1] >> 2) & 0x07));
-				res[outPos++] = (byte) (((buffer[1] >> 6) & 0xc0) | (buffer[2] << 1) | ((buffer[3] >> 4) & 0x01));
-				res[outPos++] = (byte) (((buffer[3] << 4) & 0xf0) | ((buffer[4] >> 1) & 0x0f));
-				res[outPos++] = (byte) (((buffer[4] << 7) & 0x80) | (buffer[5] << 2) | ((buffer[6] >> 3) & 0x03));
-				res[outPos++] = (byte) (((buffer[6] << 5) & 0xe0) | buffer[7]);
-			}
-
-			if (remain > 0)
-			{
-				for (int i = 0; i < 8 - paddingCount; i++)
-				{
-					buffer[i] = alphabet[inData[inPos++]];
-				}
-
-				switch (remain)
-				{
-					case 1:
-						res[outPos] = (byte) ((buffer[0] << 3) | ((buffer[1] >> 2) & 0x07));
-						break;
-					case 2:
-						res[outPos++] = (byte) ((buffer[0] << 3) | ((buffer[1] >> 2) & 0x07));
-						res[outPos] = (byte) (((buffer[1] >> 6) & 0xc0) | (buffer[2] << 1) | ((buffer[3] >> 4) & 0x01));
-						break;
-					case 3:
-						res[outPos++] = (byte) ((buffer[0] << 3) | ((buffer[1] >> 2) & 0x07));
-						res[outPos++] = (byte) (((buffer[1] >> 6) & 0xc0) | (buffer[2] << 1) | ((buffer[3] >> 4) & 0x01));
-						res[outPos] = (byte) (((buffer[3] << 4) & 0xf0) | ((buffer[4] >> 1) & 0x0f));
-						break;
-					case 4:
-						res[outPos++] = (byte) ((buffer[0] << 3) | ((buffer[1] >> 2) & 0x07));
-						res[outPos++] = (byte) (((buffer[1] >> 6) & 0xc0) | (buffer[2] << 1) | ((buffer[3] >> 4) & 0x01));
-						res[outPos++] = (byte) (((buffer[3] << 4) & 0xf0) | ((buffer[4] >> 1) & 0x0f));
-						res[outPos] = (byte) (((buffer[4] << 7) & 0x80) | (buffer[5] << 2) | ((buffer[6] >> 3) & 0x03));
-						break;
-				}
-			}
-
-			return res;
-		}
-
-		private static string ToBase32String(this byte[] inArray, int offset, int length, char[] alphabet)
-		{
-			int inRemain = length % 5;
-			int inSafeEnd = offset + length - inRemain;
-
-			int outLength = length / 5 * 8 + ((inRemain == 0) ? 0 : 8);
-
-			char[] outData = new char[outLength];
-			int outPos = 0;
-
-			int inPos = offset;
-			while (inPos < inSafeEnd)
-			{
-				outData[outPos++] = alphabet[(inArray[inPos] & 0xf8) >> 3];
-				outData[outPos++] = alphabet[((inArray[inPos] & 0x07) << 2) | ((inArray[++inPos] & 0xc0) >> 6)];
-				outData[outPos++] = alphabet[((inArray[inPos] & 0x3e) >> 1)];
-				outData[outPos++] = alphabet[((inArray[inPos] & 0x01) << 4) | ((inArray[++inPos] & 0xf0) >> 4)];
-				outData[outPos++] = alphabet[((inArray[inPos] & 0x0f) << 1) | ((inArray[++inPos] & 0x80) >> 7)];
-				outData[outPos++] = alphabet[((inArray[inPos] & 0x7c) >> 2)];
-				outData[outPos++] = alphabet[((inArray[inPos] & 0x03) << 3) | ((inArray[++inPos] & 0xe0) >> 5)];
-				outData[outPos++] = alphabet[inArray[inPos++] & 0x1f];
-			}
-
-			switch (inRemain)
-			{
-				case 1:
-					outData[outPos++] = alphabet[(inArray[inPos] & 0xf8) >> 3];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x07) << 2)];
-					outData[outPos++] = alphabet[32];
-					outData[outPos++] = alphabet[32];
-					outData[outPos++] = alphabet[32];
-					outData[outPos++] = alphabet[32];
-					outData[outPos++] = alphabet[32];
-					outData[outPos] = alphabet[32];
-					break;
-				case 2:
-					outData[outPos++] = alphabet[(inArray[inPos] & 0xf8) >> 3];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x07) << 2) | ((inArray[++inPos] & 0xc0) >> 6)];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x3e) >> 1)];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x01) << 4)];
-					outData[outPos++] = alphabet[32];
-					outData[outPos++] = alphabet[32];
-					outData[outPos++] = alphabet[32];
-					outData[outPos] = alphabet[32];
-					break;
-				case 3:
-					outData[outPos++] = alphabet[(inArray[inPos] & 0xf8) >> 3];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x07) << 2) | ((inArray[++inPos] & 0xc0) >> 6)];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x3e) >> 1)];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x01) << 4) | ((inArray[++inPos] & 0xf0) >> 4)];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x0f) << 1)];
-					outData[outPos++] = alphabet[32];
-					outData[outPos++] = alphabet[32];
-					outData[outPos] = alphabet[32];
-					break;
-				case 4:
-					outData[outPos++] = alphabet[(inArray[inPos] & 0xf8) >> 3];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x07) << 2) | ((inArray[++inPos] & 0xc0) >> 6)];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x3e) >> 1)];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x01) << 4) | ((inArray[++inPos] & 0xf0) >> 4)];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x0f) << 1) | ((inArray[++inPos] & 0x80) >> 7)];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x7c) >> 2)];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x03) << 3)];
-					outData[outPos] = alphabet[32];
-					break;
-			}
-
-			return new string(outData);
-		}
-		#endregion
-
-		#region Base64
-		private const string _BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-		private static readonly char[] _base64Alphabet = _BASE64_ALPHABET.ToCharArray();
-		private static readonly Dictionary<char, byte> _base64ReverseAlphabet = GetAlphabet(_BASE64_ALPHABET, false);
-
-		/// <summary>
-		///   Decodes a Base64 string as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inData"> An Base64 encoded string. </param>
-		/// <returns> Decoded data </returns>
-		public static byte[] FromBase64String(this string inData)
-		{
-			return inData.ToCharArray().FromBase64CharArray(0, inData.Length);
-		}
-
-		/// <summary>
-		///   Decodes a Base64 char array as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inData"> An Base64 encoded char array. </param>
-		/// <param name="offset"> An offset in inData. </param>
-		/// <param name="length"> The number of elements of inData to decode. </param>
-		/// <returns> Decoded data </returns>
-		public static byte[] FromBase64CharArray(this char[] inData, int offset, int length)
-		{
-			return inData.FromBase64CharArray(offset, length, _base64ReverseAlphabet);
-		}
-
-		/// <summary>
-		///   Converts a byte array to its corresponding Base64 encoding described in
-		///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inArray"> An array of 8-bit unsigned integers. </param>
-		/// <returns> Encoded string </returns>
-		public static string ToBase64String(this byte[] inArray)
-		{
-			return inArray.ToBase64String(0, inArray.Length);
-		}
-
-		/// <summary>
-		///   Converts a byte array to its corresponding Base64 encoding described in
-		///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inArray"> An array of 8-bit unsigned integers. </param>
-		/// <param name="offset"> An offset in inArray. </param>
-		/// <param name="length"> The number of elements of inArray to convert. </param>
-		/// <returns> Encoded string </returns>
-		public static string ToBase64String(this byte[] inArray, int offset, int length)
-		{
-			return inArray.ToBase64String(offset, length, _base64Alphabet);
-		}
-
-		private const string _BASE64_URL_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=";
-		private static readonly char[] _base64UrlAlphabet = _BASE64_URL_ALPHABET.ToCharArray();
-		private static readonly Dictionary<char, byte> _base64UrlReverseAlphabet = GetAlphabet(_BASE64_URL_ALPHABET, false);
-
-		/// <summary>
-		///   Decodes a Base64Url string as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inData"> An Base64Url encoded string. </param>
-		/// <returns> Decoded data </returns>
-		public static byte[] FromBase64UrlString(this string inData)
-		{
-			return inData.ToCharArray().FromBase64UrlCharArray(0, inData.Length);
-		}
-
-		/// <summary>
-		///   Decodes a Base64Url char array as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inData"> An Base64Url encoded char array. </param>
-		/// <param name="offset"> An offset in inData. </param>
-		/// <param name="length"> The number of elements of inData to decode. </param>
-		/// <returns> Decoded data </returns>
-		public static byte[] FromBase64UrlCharArray(this char[] inData, int offset, int length)
-		{
-			return inData.FromBase64CharArray(offset, length, _base64UrlReverseAlphabet);
-		}
-
-		/// <summary>
-		///   Converts a byte array to its corresponding Base64Url encoding described in
-		///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inArray"> An array of 8-bit unsigned integers. </param>
-		/// <returns> Encoded string </returns>
-		public static string ToBase64UrlString(this byte[] inArray)
-		{
-			return inArray.ToBase64UrlString(0, inArray.Length);
-		}
-
-		/// <summary>
-		///   Converts a byte array to its corresponding Base64Url encoding described in
-		///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
-		/// </summary>
-		/// <param name="inArray"> An array of 8-bit unsigned integers. </param>
-		/// <param name="offset"> An offset in inArray. </param>
-		/// <param name="length"> The number of elements of inArray to convert. </param>
-		/// <returns> Encoded string </returns>
-		public static string ToBase64UrlString(this byte[] inArray, int offset, int length)
-		{
-			return inArray.ToBase64String(offset, length, _base64UrlAlphabet);
-		}
-
-		private static byte[] FromBase64CharArray(this char[] inData, int offset, int length, Dictionary<char, byte> alphabet)
-		{
-			int paddingCount;
-			int remain;
-
-			if (alphabet[inData[offset + length - 2]] == 64)
-			{
-				paddingCount = 2;
-				remain = 1;
-			}
-			else if (alphabet[inData[offset + length - 1]] == 64)
-			{
-				paddingCount = 1;
-				remain = 2;
-			}
-			else
-			{
-				paddingCount = 0;
-				remain = 0;
-			}
-
-			int outSafeLength = (length - paddingCount) / 4 * 3;
-
-			byte[] res = new byte[outSafeLength + remain];
-
-			int inPos = offset;
-			int outPos = 0;
-
-			byte[] buffer = new byte[4];
-
-			while (outPos < outSafeLength)
-			{
-				for (int i = 0; i < 4; i++)
-				{
-					buffer[i] = alphabet[inData[inPos++]];
-				}
-
-				res[outPos++] = (byte) ((buffer[0] << 2) | ((buffer[1] >> 4) & 0x03));
-				res[outPos++] = (byte) (((buffer[1] << 4) & 0xf0) | ((buffer[2] >> 2) & 0x0f));
-				res[outPos++] = (byte) (((buffer[2] << 6) & 0xc0) | (buffer[3] & 0x3f));
-			}
-
-			if (remain > 0)
-			{
-				for (int i = 0; i < 4 - paddingCount; i++)
-				{
-					buffer[i] = alphabet[inData[inPos++]];
-				}
-
-				switch (remain)
-				{
-					case 1:
-						res[outPos] = (byte) ((buffer[0] << 2) | ((buffer[1] >> 4) & 0x03));
-						break;
-					case 2:
-						res[outPos++] = (byte) ((buffer[0] << 2) | ((buffer[1] >> 4) & 0x03));
-						res[outPos] = (byte) (((buffer[1] << 4) & 0xf0) | ((buffer[2] >> 2) & 0x0f));
-						break;
-				}
-			}
-
-			return res;
-		}
-
-		private static string ToBase64String(this byte[] inArray, int offset, int length, char[] alphabet)
-		{
-			int inRemain = length % 3;
-			int inSafeEnd = offset + length - inRemain;
-
-			int outLength = length / 3 * 4 + ((inRemain == 0) ? 0 : 4);
-
-			char[] outData = new char[outLength];
-			int outPos = 0;
-
-			int inPos = offset;
-			while (inPos < inSafeEnd)
-			{
-				outData[outPos++] = alphabet[(inArray[inPos] & 0xfc) >> 2];
-				outData[outPos++] = alphabet[((inArray[inPos] & 0x03) << 4) | ((inArray[++inPos] & 0xf0) >> 4)];
-				outData[outPos++] = alphabet[((inArray[inPos] & 0x0f) << 2) | ((inArray[++inPos] & 0xc0) >> 6)];
-				outData[outPos++] = alphabet[inArray[inPos++] & 0x3f];
-			}
-
-			switch (inRemain)
-			{
-				case 1:
-					outData[outPos++] = alphabet[(inArray[inPos] & 0xfc) >> 2];
-					outData[outPos++] = alphabet[(inArray[inPos] & 0x03) << 4];
-					outData[outPos++] = alphabet[64];
-					outData[outPos] = alphabet[64];
-					break;
-				case 2:
-					outData[outPos++] = alphabet[(inArray[inPos] & 0xfc) >> 2];
-					outData[outPos++] = alphabet[((inArray[inPos] & 0x03) << 4) | ((inArray[++inPos] & 0xf0) >> 4)];
-					outData[outPos++] = alphabet[(inArray[inPos] & 0x0f) << 2];
-					outData[outPos] = alphabet[64];
-					break;
-			}
-
-			return new string(outData);
-		}
-		#endregion
-	}
+    public static class BaseEncoding
+    {
+        private static readonly char[] Base16Alphabet = "0123456789ABCDEF".ToCharArray();
+        private static readonly Dictionary<char, byte> Base16AlphabetReverseLookup = GetAlphabetReverseLookup(Base16Alphabet, true);
+
+        private static readonly char[] Base32Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".ToCharArray();
+        private static readonly Dictionary<char, byte> Base32AlphabetReverseLookup = GetAlphabetReverseLookup(Base32Alphabet, true);
+
+        private static readonly char[] Base32HexAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUV".ToCharArray();
+        private static readonly Dictionary<char, byte> Base32HexAlphabetReverseLookup = GetAlphabetReverseLookup(Base32HexAlphabet, true);
+
+        private static readonly char[] Base64Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".ToCharArray();
+        private static readonly Dictionary<char, byte> Base64AlphabetAlphabetReverseLookup = GetAlphabetReverseLookup(Base64Alphabet, false);
+
+        private static readonly char[] Base64UrlAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".ToCharArray();
+        private static readonly Dictionary<char, byte> Base64UrlAlphabetAlphabetReverseLookup = GetAlphabetReverseLookup(Base64UrlAlphabet, false);
+
+        #region Helper
+        private static Dictionary<char, byte> GetAlphabetReverseLookup(char[] alphabet, bool isCaseIgnored)
+        {
+            Dictionary<char, byte> res = new Dictionary<char, byte>(isCaseIgnored ? 2 * alphabet.Length : alphabet.Length);
+
+            for (byte i = 0; i < alphabet.Length; i++)
+            {
+                res[alphabet[i]] = i;
+            }
+
+            if (isCaseIgnored)
+            {
+                for (byte i = 0; i < alphabet.Length; i++)
+                {
+                    res[char.ToLowerInvariant(alphabet[i])] = i;
+                }
+            }
+
+            return res;
+        }
+        #endregion
+
+
+        /// <summary>
+        ///   Decodes a Base16 string as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
+        /// </summary>
+        /// <param name="inData"> An Base16 encoded string. </param>
+        /// <returns> Decoded data </returns>
+        public static byte[] FromBase16String(this string inData)
+        {
+            return Decode(inData, Base16Alphabet, Base16AlphabetReverseLookup);
+        }
+
+        /// <summary>
+        ///   Converts a byte array to its corresponding Base16 encoding described in
+        ///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
+        /// </summary>
+        /// <param name="inArray"> An array of 8-bit unsigned integers. </param>
+        /// <returns> Encoded string </returns>
+        public static string ToBase16String(this byte[] inArray)
+        {
+            return Encode(inArray, Base16Alphabet);
+        }
+
+        /// <summary>
+        ///   Decodes a Base32 string as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
+        /// </summary>
+        /// <param name="inData"> An Base32 encoded string. </param>
+        /// <returns> Decoded data </returns>
+        public static byte[] FromBase32String(this string inData)
+        {
+            return Decode(inData, Base32Alphabet, Base32AlphabetReverseLookup);
+        }
+
+        /// <summary>
+        ///   Converts a byte array to its corresponding Base32 encoding described in
+        ///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
+        /// </summary>
+        /// <param name="inArray"> An array of 8-bit unsigned integers. </param>
+        /// <returns> Encoded string </returns>
+        public static string ToBase32String(this byte[] inArray)
+        {
+            return Encode(inArray, Base32Alphabet);
+        }
+
+        /// <summary>
+        ///   Decodes a Base32Hex string as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
+        /// </summary>
+        /// <param name="inData"> An Base32Hex encoded string. </param>
+        /// <returns> Decoded data </returns>
+        public static byte[] FromBase32HexString(this string inData)
+        {
+            return Decode(inData, Base32HexAlphabet, Base32HexAlphabetReverseLookup);
+        }
+
+        /// <summary>
+        ///   Converts a byte array to its corresponding Base32Hex encoding described in
+        ///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
+        /// </summary>
+        /// <param name="inArray"> An array of 8-bit unsigned integers. </param>
+        /// <returns> Encoded string </returns>
+        public static string ToBase32HexString(this byte[] inArray)
+        {
+            return Encode(inArray, Base32HexAlphabet);
+        }
+
+        /// <summary>
+        ///   Decodes a Base64 string as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
+        /// </summary>
+        /// <param name="inData"> An Base64 encoded string. </param>
+        /// <returns> Decoded data </returns>
+        public static byte[] FromBase64String(this string inData)
+        {
+            return Decode(inData, Base64Alphabet, Base64AlphabetAlphabetReverseLookup);
+        }
+
+        /// <summary>
+        ///   Converts a byte array to its corresponding Base64 encoding described in
+        ///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
+        /// </summary>
+        /// <param name="inArray"> An array of 8-bit unsigned integers. </param>
+        /// <returns> Encoded string </returns>
+        public static string ToBase64String(this byte[] inArray)
+        {
+            return Encode(inArray, Base64Alphabet);
+        }
+
+        /// <summary>
+        ///   Decodes a Base64Url string as described in <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
+        /// </summary>
+        /// <param name="inData"> An Base64Url encoded string. </param>
+        /// <returns> Decoded data </returns>
+        public static byte[] FromBase64UrlString(this string inData)
+        {
+            return Decode(inData, Base64UrlAlphabet, Base64UrlAlphabetAlphabetReverseLookup);
+        }
+
+        /// <summary>
+        ///   Converts a byte array to its corresponding Base64Url encoding described in
+        ///   <a href="https://www.rfc-editor.org/rfc/rfc4648.html">RFC 4648</a>.
+        /// </summary>
+        /// <param name="inArray"> An array of 8-bit unsigned integers. </param>
+        /// <returns> Encoded string </returns>
+        public static string ToBase64UrlString(this byte[] inArray)
+        {
+            return Encode(inArray, Base64UrlAlphabet);
+        }
+
+
+        private static byte[] Decode(string input, char[] alphabet, Dictionary<char,byte> reverseAlphabetLookup)
+        {
+            if (input == null)
+                throw new ArgumentNullException(nameof(input));
+
+            int bitsPerPlainByte = 8;
+            GetBaseEncodingParams(alphabet.Length, out var _, out var bitsPerEncodedByte);
+
+            input = input.TrimEnd('='); // Just remove any padding
+
+            int byteCount = input.Length * bitsPerEncodedByte / bitsPerPlainByte; // Number of bytes after decoding
+            byte[] bytes = new byte[byteCount];
+
+            int bitCount = 0;
+            int index = 0;
+            int value = 0;
+
+            foreach (char c in input)
+            {
+                int charValue = reverseAlphabetLookup[c];
+                value = (value << bitsPerEncodedByte) | charValue;
+                bitCount += bitsPerEncodedByte;
+
+                if (bitCount >= bitsPerPlainByte)
+                {
+                    bytes[index++] = (byte)(value >> (bitCount - bitsPerPlainByte));
+                    bitCount -= bitsPerPlainByte;
+                }
+            }
+
+            return bytes;
+        }
+
+        private static string Encode(byte[] bytes, char[] alphabet)
+        {
+            if (bytes == null)
+                throw new ArgumentNullException(nameof(bytes));
+
+            int bitsPerPlainByte = 8;
+            GetBaseEncodingParams(alphabet.Length, out var encodedBlockBytes, out var bitsPerEncodedByte);
+
+            int charCount = (bytes.Length * bitsPerPlainByte / bitsPerEncodedByte) + ((bytes.Length * bitsPerPlainByte % bitsPerEncodedByte) != 0 ? 1 : 0); // divide, ceil
+            int paddingCount = (charCount % encodedBlockBytes == 0) ? 0 : (encodedBlockBytes - charCount % encodedBlockBytes);
+            char[] chars = new char[charCount + paddingCount];
+
+            int baseMax = alphabet.Length - 1;
+            int bitCount = 0;
+            int index = 0;
+            int value = 0;
+
+            foreach (byte b in bytes)
+            {
+                value = (value << bitsPerPlainByte) | b;
+                bitCount += bitsPerPlainByte;
+
+                while (bitCount >= bitsPerEncodedByte)
+                {
+                    int charValue = (value >> (bitCount - bitsPerEncodedByte)) & baseMax;
+                    chars[index++] = alphabet[charValue];
+                    bitCount -= bitsPerEncodedByte;
+                }
+            }
+
+            if (bitCount > 0)
+            {
+                int charValue = (value << (bitsPerEncodedByte - bitCount)) & baseMax;
+                chars[index++] = alphabet[charValue];
+            }
+
+            while (index < charCount + paddingCount)
+            {
+                chars[index++] = '=';
+            }
+
+            return new string(chars);
+        }
+
+        private static void GetBaseEncodingParams(int baseEncoding, out int encodedBlockBytes, out int bitsPerEncodedbyte)
+        {
+            switch (baseEncoding)
+            {
+                case 16:
+                    encodedBlockBytes = 2;
+                    bitsPerEncodedbyte = 4;
+                    break;
+                case 32:
+                    encodedBlockBytes = 8;
+                    bitsPerEncodedbyte = 5;
+                    break;
+                case 64:
+                    encodedBlockBytes = 4;
+                    bitsPerEncodedbyte = 6;
+                    break;
+                default:
+                    throw new ArgumentException("Unsupported base {baseEncoding}", nameof(baseEncoding));
+            }
+        }
+    }
 }

--- a/ARSoft.Tools.Net/Dns/DnsSec/DiffieHellmanKeyRecord.cs
+++ b/ARSoft.Tools.Net/Dns/DnsSec/DiffieHellmanKeyRecord.cs
@@ -92,7 +92,7 @@ namespace ARSoft.Tools.Net.Dns
 
 			EncodePublicKey(publicKey, ref currentPosition, null);
 
-			return publicKey.ToBase64String(0, currentPosition);
+			return publicKey[0..currentPosition].ToBase64String();
 		}
 
 		protected override int MaximumPublicKeyLength => 3 + Prime.Length + Generator.Length + PublicValue.Length;


### PR DESCRIPTION
The Base32Hex decoding function did not work correctly, and the whole BaseEncoding class was quite difficult to follow, this replaces the BaseEncoding implementation with a more readable implementation

Also adds basic tests based on the RFC4648 test vectors.